### PR TITLE
フォント選択機能追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,10 +7,14 @@ sourceCompatibility = 1.7
 
 repositories {
     mavenCentral()
+    maven {
+        url "http://jfontchooser.osdn.jp/repository/"
+    }
 }
 dependencies {
     compile 'org.apache.xmlgraphics:batik-svggen:1.9'
     compile 'org.apache.xmlgraphics:batik-dom:1.9'
+    compile 'say.swing:jfontchooser:1.0.5'
     testCompile group: 'junit', name: 'junit', version: '4.11'
 }
 

--- a/src/main/java/padtools/Main.java
+++ b/src/main/java/padtools/Main.java
@@ -19,6 +19,17 @@ public class Main {
         if(setting == null) throw new RuntimeException("Setting is not set");
         return setting;
     }
+    /**
+     * Settingを保存する
+     */
+    public static void saveSetting(){
+        File setting_file = new File(PathUtil.getBasePath(), "settings.xml");
+        try{
+            setting.saveToFile(setting_file);
+        }catch(IOException e){
+            e.printStackTrace();
+        }
+    }
 
     /**
      * エントリポイント

--- a/src/main/java/padtools/Setting.java
+++ b/src/main/java/padtools/Setting.java
@@ -1,5 +1,7 @@
 package padtools;
 
+import java.awt.Color;
+import java.awt.Font;
 import java.beans.XMLDecoder;
 import java.beans.XMLEncoder;
 import java.io.*;
@@ -10,7 +12,15 @@ public class Setting {
 
     /** ツールバーを無効にする */
     private boolean disableToolbar = false;
-
+    
+    // fonts
+    /** エディタのデフォルトフォント */
+    private Font editorFont = new Font("Dialog", Font.PLAIN, 14);
+    /** PAD図のフォント */
+    private Font viewFont   = new Font("Dialog", Font.PLAIN, 14);
+    /** PAD図の前景色 */
+    private Color viewColor=new Color(0.2f, 0.2f, 0.2f);
+    
     public boolean isDisableSaveMenu() {
         return disableSaveMenu;
     }
@@ -22,6 +32,24 @@ public class Setting {
     }
     public void setDisableToolbar(boolean disableToolbar) {
         this.disableToolbar = disableToolbar;
+    }
+    public Font getEditorFont(){
+        return editorFont;
+    }
+    public void setEditorFont(Font editorFont){
+        this.editorFont = editorFont;
+    }
+    public Font getViewFont(){
+        return viewFont;
+    }
+    public void setViewFont(Font viewFont){
+        this.viewFont = viewFont;
+    }
+    public Color getViewColor(){
+        return viewColor;
+    }
+    public void setViewColor(Color viewColor){
+        this.viewColor = viewColor;
     }
 
     public void saveToFile(File f) throws IOException {

--- a/src/main/java/padtools/editor/MainFrame.java
+++ b/src/main/java/padtools/editor/MainFrame.java
@@ -680,10 +680,9 @@ public class MainFrame extends JFrame {
                         Integer.toString((int)r.getWidth())+" "+
                         Integer.toString((int)r.getHeight())
         );
-        try {
-           OutputStream os = new FileOutputStream(f);
-           BufferedOutputStream bos = new BufferedOutputStream(os);
-           Writer out = new OutputStreamWriter(bos, "UTF-8");
+        try (OutputStream os = new FileOutputStream(f);
+             BufferedOutputStream bos = new BufferedOutputStream(os);
+             Writer out = new OutputStreamWriter(bos, "UTF-8");){
            svg2d.stream(sv,out);
         } catch (UnsupportedEncodingException ue){
             ue.printStackTrace();
@@ -708,7 +707,6 @@ public class MainFrame extends JFrame {
         }
 
         fc.setSelectedFile(sel);
-        File svgfile = fc.getSelectedFile();
 
         if (fc.showSaveDialog(MainFrame.this) == JFileChooser.APPROVE_OPTION) {
             outputSVG(fc.getSelectedFile());

--- a/src/main/java/padtools/editor/SPDEditor.java
+++ b/src/main/java/padtools/editor/SPDEditor.java
@@ -9,6 +9,7 @@ import java.awt.Graphics;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JComponent;
@@ -25,6 +26,8 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.TabSet;
 import javax.swing.text.TabStop;
+
+import padtools.Main;
 /**
  * LPDを編集するペイン。
  * @author monaou
@@ -90,6 +93,13 @@ class SPDEditor extends JTextPane {
             keywords.add(":case");
             keywords.add(":call");
             keywords.add(":terminal");
+        }
+        
+        @Override
+        public Font getFont(AttributeSet attr){
+            Font f = super.getFont(attr);
+            Font base = SPDEditor.this.getFont();
+            return base.deriveFont(f.getStyle());
         }
 
         @Override
@@ -179,7 +189,7 @@ class SPDEditor extends JTextPane {
         doc.setParagraphAttributes(0, doc.getLength(), attr, true);
         
         //タブを設定する。
-        setFont(new Font("Dialog", Font.PLAIN, 14));
+        setFont(Main.getSetting().getEditorFont());
         FontMetrics fm = getFontMetrics(getFont());
         int charWidth = fm.charWidth('m');
         int tabLength = charWidth * 2;
@@ -197,6 +207,13 @@ class SPDEditor extends JTextPane {
 
         //右クリックメニューをつける
         new JTextEditPopupMenu(this).assignEvent();
+    }
+    
+    public void updateFont(Font font){
+        if(!Objects.equals(font, getFont())){
+            setFont(font);
+            setText(getText()); //rerendering
+        }
     }
     
     public void setErrorLine(int line){


### PR DESCRIPTION
ViewOptionで折角設定可能になっている様なので、フォント選択できるようにしてみました。
バグ修正ではありませんので、気が向いたら取りこんで頂けるとありがたいです。

1. エディタのフォントを変えられる様にしました。（メニュー >表示 >　エディタフォント)
1. PAD図のフォントを変えられる様にしました。(メニュー > 表示 > PAD図フォント)
1. PAD図の色を変えられる様にしました。(メニュー > 表示 > PAD図カラー)
1. 上記設定を復元できるようにpadtools.Settingを拡張しました。


フォント選択ダイアログには、say.swint.JFontChooserを利用しています。