### PR TITLE
Fix: 1つの :if に複数の :else がある場合に構文エラーを出すように修正 (#11)

### DIFF
--- a/src/main/java/padtools/core/formats/spd/SPDParser.java
+++ b/src/main/java/padtools/core/formats/spd/SPDParser.java
@@ -247,7 +247,11 @@ public class SPDParser {
                 node.setTrueNode(newNode);
             }
             else if(context.parent.optionStatus == Context.OptionStatus.Else){
-                node.setFalseNode(newNode);
+                if(node.getFalseNode() == null){
+                    node.setFalseNode(newNode);
+                }else{
+                    throw new UnexpectedElseException();
+                }
             }
             else {
                 throw new UnexpectedInnerExpection("Illegal option status");


### PR DESCRIPTION
## 概要

Issue #11 に関連する修正です。

1つの `:if` に対して複数の `:else` が記述されてもエラーにならず、後続の `:else` が上書きされる不具合がありました。

このPRでは、2つ目の `:else` を検出した時点で `UnexpectedElseException` を投げるように変更したつもりです。

お手数をおかけしてすいませんが、確認よろしくお願いします。

